### PR TITLE
adapt(hosts/mutation-dialog): sending string ports instead of number

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -68,7 +68,7 @@ class UserCreate(User):
         json_schema_extra={
             "example": {
                 "username": "user1234",
-                "services": [1, 2, 3],
+                "service_ids": [1, 2, 3],
                 "expire_strategy": "start_on_first_use",
                 "usage_duration": 86400 * 14,
                 "activation_deadline": "2024-11-03T20:30:00",

--- a/dashboard/src/features/hosts/dialogs/mutation/fields/port.tsx
+++ b/dashboard/src/features/hosts/dialogs/mutation/fields/port.tsx
@@ -20,7 +20,7 @@ export const PortField = () => {
                 <FormItem className="w-1/3">
                     <FormLabel>{t('port')}</FormLabel>
                     <FormControl>
-                        <Input type="number" {...field} />
+                        <Input {...field} />
                     </FormControl>
                     <FormMessage />
                 </FormItem>

--- a/dashboard/src/features/hosts/dialogs/mutation/index.tsx
+++ b/dashboard/src/features/hosts/dialogs/mutation/index.tsx
@@ -41,7 +41,7 @@ interface HostMutationDialogProps extends MutationDialogProps<HostType> {
 }
 
 const transformFormValue = (values: HostType) => {
-    const port = values.port === "" ? null : values.port;
+    const port = values.port === "" ? null : String(values.port);
     const alpn = values.alpn === "none" ? "" : values.alpn;
     const fingerprint = values.fingerprint === "none" ? "" : values.fingerprint;
     return { ...values, alpn, fingerprint, port };


### PR DESCRIPTION
- **docs(api): Correct JSON schema example to use 'service_ids' instead of 'services' (#580)**
- **adapt(hosts/dialog-mutation): sending string instead of number**
